### PR TITLE
Specify McEmojiPicker version

### DIFF
--- a/ios/EmojiPickerModule.podspec
+++ b/ios/EmojiPickerModule.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
   s.static_framework = true
 
   s.dependency 'ExpoModulesCore'
-  s.dependency 'MCEmojiPicker'
+  s.dependency 'MCEmojiPicker', '1.2.3'
 
   # Swift/Objective-C compatibility
   s.pod_target_xcconfig = {


### PR DESCRIPTION
1.2.5 crashes in production, but 1.2.3 works just fine